### PR TITLE
Fixed bug in parsing decimal values

### DIFF
--- a/src/BinaryFormatDataStructure/BinaryFormatterReader.cs
+++ b/src/BinaryFormatDataStructure/BinaryFormatterReader.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Runtime.Serialization;
@@ -509,7 +510,7 @@ namespace BinaryFormatDataStructure
 
                         for (int i = 0; i < result.Length; i++)
                         {
-                            result[i] = _reader.ReadDecimal();
+                            result[i] = decimal.Parse(_reader.ReadString(), CultureInfo.InvariantCulture);
                         }
 
                         return result;

--- a/src/BinaryFormatDataStructure/PrimitiveReader.cs
+++ b/src/BinaryFormatDataStructure/PrimitiveReader.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 using System.IO;
 using System.Runtime.Serialization;
 
@@ -61,7 +62,7 @@ namespace BinaryFormatDataStructure
                     return reader.ReadUInt64();
 
                 case PrimitiveType.Decimal:
-                    return reader.ReadDecimal();
+                    return decimal.Parse(reader.ReadString(), CultureInfo.InvariantCulture);
 
                 case PrimitiveType.TimeSpan:
                     return ReadTimeSpan(reader);

--- a/src/Tests/CustomClassTests.cs
+++ b/src/Tests/CustomClassTests.cs
@@ -27,7 +27,7 @@ namespace BinaryFormatDataStructureTests
             BinaryObject objectResult = (BinaryObject)result;
             Assert.AreEqual("Tests, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null", objectResult.AssemblyName);
             Assert.AreEqual("BinaryFormatDataStructureTests.CustomClassTests+TestModel", objectResult.TypeName);
-            Assert.AreEqual(2, objectResult.Keys.Count());
+            Assert.AreEqual(3, objectResult.Keys.Count());
 
             var enumer = objectResult.GetEnumerator();
             enumer.MoveNext();
@@ -41,6 +41,12 @@ namespace BinaryFormatDataStructureTests
             Assert.AreEqual("_two", current.Key);
             Assert.IsInstanceOfType(current.Value, typeof(bool));
             Assert.AreEqual(true, (bool)current.Value);
+
+            enumer.MoveNext();
+            current = enumer.Current;
+            Assert.AreEqual("_three", current.Key);
+            Assert.IsInstanceOfType(current.Value, typeof(decimal));
+            Assert.AreEqual(decimal.MaxValue, (decimal)current.Value);
         }
 
         [TestMethod]
@@ -99,6 +105,8 @@ namespace BinaryFormatDataStructureTests
 #pragma warning restore IDE0044 // Add readonly modifier
 
             public decimal Three { get { return 0; } set { } }
+
+            private decimal _three = decimal.MaxValue;
         }
 
         private enum TestEnum

--- a/src/Tests/PrimitiveArrayTests.cs
+++ b/src/Tests/PrimitiveArrayTests.cs
@@ -30,6 +30,26 @@ namespace BinaryFormatDataStructureTests
         }
 
         [TestMethod]
+        public void TestDecimalArray()
+        {
+            BinaryFormatter formatter = new BinaryFormatter();
+            MemoryStream ms = new MemoryStream();
+
+            formatter.Serialize(ms, new decimal[] { 1.1m, 2.2m, 3.3m });
+            ms.Position = 0;
+
+            object result = NRBFReader.ReadStream(ms);
+
+            Assert.IsInstanceOfType(result, typeof(decimal[]));
+
+            decimal[] arrayResult = (decimal[])result;
+            Assert.AreEqual(3, arrayResult.Length);
+            Assert.AreEqual(1.1m, arrayResult[0]);
+            Assert.AreEqual(2.2m, arrayResult[1]);
+            Assert.AreEqual(3.3m, arrayResult[2]);
+        }
+
+        [TestMethod]
         public void TestTimeSpanArray()
         {
             BinaryFormatter formatter = new BinaryFormatter();


### PR DESCRIPTION
I have found a bug in parsing `decimal` values. 

The NRBF specification (section 2.1.1.7) says that decimals are `serialized` as their string representation. Also, .NET Framework seems to use [`WriteString` with `CultureInfo.InvariantCulture`](https://referencesource.microsoft.com/#mscorlib/system/runtime/serialization/formatters/binary/binaryformatterwriter.cs,98).

I've also extended the tests to cover this scenario.